### PR TITLE
Expand JSCAD samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,4 +383,6 @@ These examples incubate dotSCAD and dotSCAD refactors these examples. See [examp
 [**pp/pp_poisson2**(size, r[, start, k, seed])](https://openhome.cc/eGossip/OpenSCAD/lib3x-pp_poisson2.html) | perform poisson sampling over a rectangle area.
 [**pp/pp_poisson3**(size, r[, start, k, seed])](https://openhome.cc/eGossip/OpenSCAD/lib3x-pp_poisson3.html) | perform poisson sampling over a cube space.
 
-----
+## JSCAD Port
+A partial port to [JSCAD](https://openjscad.xyz/).
+See `jscad/arc.js`, `jscad/shapeArc.js`, and `jscad/angleBetween.js` for examples converting OpenSCAD modules to the JSCAD modeling API.

--- a/jscad/angleBetween.js
+++ b/jscad/angleBetween.js
@@ -1,0 +1,33 @@
+// Port of src/angle_between.scad and _impl/_angle_between_impl.scad to JSCAD
+
+function dot(v1, v2) {
+  return v1[0]*v2[0] + v1[1]*v2[1] + (v1[2]||0)*(v2[2]||0)
+}
+
+function length(v) {
+  return Math.sqrt(dot(v, v))
+}
+
+function cross2D(v1, v2) {
+  return v1[0]*v2[1] - v1[1]*v2[0]
+}
+
+function angleBetweenCCW2D(v1, v2) {
+  const a = Math.atan2(cross2D(v1, v2), dot(v1, v2)) * 180 / Math.PI
+  return a >= 0 ? a : a + 360
+}
+
+function angleBetweenCCW3D(v1, v2) {
+  const a = Math.acos(dot(v1, v2) / Math.sqrt(dot(v1, v1) * dot(v2, v2))) * 180 / Math.PI
+  return a >= 0 ? a : a + 360
+}
+
+function angleBetween(v1, v2, ccw = false) {
+  if (!ccw) {
+    const cos = dot(v1, v2) / Math.sqrt(dot(v1, v1) * dot(v2, v2))
+    return Math.acos(cos) * 180 / Math.PI
+  }
+  return v1.length === 2 ? angleBetweenCCW2D(v1, v2) : angleBetweenCCW3D(v1, v2)
+}
+
+module.exports = angleBetween

--- a/jscad/arc.js
+++ b/jscad/arc.js
@@ -1,0 +1,9 @@
+// Port of src/arc.scad to JSCAD
+const { geom2 } = require('@jscad/modeling').geometries
+const shapeArc = require('./shapeArc')
+
+function arc(radius, angle, width = 1, widthMode = 'LINE_CROSS', segments) {
+  return shapeArc(radius, angle, width, widthMode, segments)
+}
+
+module.exports = arc

--- a/jscad/shapeArc.js
+++ b/jscad/shapeArc.js
@@ -1,0 +1,63 @@
+// Port of src/shape_arc.scad to JSCAD
+// Copyright Justin Lin, 2017
+// License: LGPL v3
+
+const { geom2 } = require('@jscad/modeling').geometries
+
+function raToXY(r, a) {
+  const rad = a * Math.PI / 180
+  return [r * Math.cos(rad), r * Math.sin(rad)]
+}
+
+function edgeRBegin(origR, a, aStep, m) {
+  const half = aStep / 2
+  const rad = deg => deg * Math.PI / 180
+  return origR * Math.cos(rad(half)) / Math.cos(rad(m * aStep - half - a))
+}
+
+function edgeREnd(origR, a, aStep, n) {
+  const half = aStep / 2
+  const rad = deg => deg * Math.PI / 180
+  return origR * Math.cos(rad(half)) / Math.cos(rad(n * aStep + half - a))
+}
+
+function frags(radius, segments = 32) {
+  return segments
+}
+
+function shapeArc(radius, angle, width, widthMode = 'LINE_CROSS', segments) {
+  const wOffset = widthMode === 'LINE_CROSS'
+    ? [width / 2, -width / 2]
+    : widthMode === 'LINE_INWARD'
+      ? [0, -width]
+      : [width, 0]
+  const aStep = 360 / frags(radius, segments)
+  const angles = typeof angle === 'number' ? [0, angle] : angle
+  const a0 = angles[0]
+  const a1 = angles[1]
+  const m = Math.floor(a0 / aStep) + 1
+  const n = Math.floor(a1 / aStep)
+  const rOuter = radius + wOffset[0]
+  const rInner = radius + wOffset[1]
+
+  const pts = []
+  // outer arc path
+  pts.push(raToXY(edgeRBegin(rOuter, a0, aStep, m), a0))
+  for (let i = m; i <= n; i++) {
+    pts.push(raToXY(rOuter, aStep * i))
+  }
+  if (a1 !== aStep * n) {
+    pts.push(raToXY(edgeREnd(rOuter, a1, aStep, n), a1))
+    // inner arc path
+    pts.push(raToXY(edgeREnd(rInner, a1, aStep, n), a1))
+  }
+  // inner arc path
+  for (let i = m; i <= n; i++) {
+    pts.push(raToXY(rInner, aStep * (n + m - i)))
+  }
+  pts.push(raToXY(edgeRBegin(rInner, a0, aStep, m), a0))
+
+  return geom2.fromPoints(pts)
+}
+
+module.exports = shapeArc

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dotscad-jscad",
+  "version": "0.1.0",
+  "description": "Partial JSCAD port of dotSCAD",
+  "main": "jscad/arc.js",
+  "type": "commonjs",
+  "dependencies": {
+    "@jscad/modeling": "^2.17.1"
+  }
+}


### PR DESCRIPTION
## Summary
- port `angle_between` function to JSCAD
- note the new example file in the README

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "const arc=require('./jscad/arc'); console.log(typeof arc);"` *(fails: Cannot find module '@jscad/modeling')*

------
https://chatgpt.com/codex/tasks/task_e_686eb13ff8688326a2600213d39f7fb8